### PR TITLE
Add dual cycling typewriter lines to hero

### DIFF
--- a/src/sections/Hero/Hero.style.ts
+++ b/src/sections/Hero/Hero.style.ts
@@ -120,6 +120,17 @@ export const HeroSubtitle = styled.p`
   line-height: 1.6;
 `
 
+export const HeroJoke = styled.p`
+  font-size: clamp(0.8rem, 1.5vw, 0.95rem);
+  color: ${props => props.theme.accent};
+  opacity: 0.5;
+  font-weight: 400;
+  max-width: 560px;
+  line-height: 1.6;
+  margin-top: 0.25rem;
+  font-style: italic;
+`
+
 export const HeroBio = styled.p`
   font-size: 1rem;
   color: ${props => props.theme.color};

--- a/src/sections/Hero/Hero.tsx
+++ b/src/sections/Hero/Hero.tsx
@@ -3,10 +3,14 @@ import * as S from "./Hero.style"
 import * as Sec from "constants/SectionConstants"
 import useTypewriter from "hooks/useTypewriter"
 
-const TITLES = ["Senior Software Engineer @Capital One", "Software Engineer @Seamgen", "Song Writer"]
+const TITLES = ["Senior Software Engineer @Capital One", "M.S. in Computer Science @Georgia Tech", "B.S. in Statistics @UIUC"]
+const JOKES = ["Burning Tokens @Claude Code", "Professional Overthinker @3AM", "Bench Warmer @Sunday League", "Principal Song Writer @Bedroom", "Senior Reserve Member @Starbucks"]
+// Song Writer
+// Software Engineer @Seamgen
 
 const Hero: React.FC = () => {
   const { displayText } = useTypewriter(TITLES)
+  const { displayText: jokeText } = useTypewriter(JOKES, 45, 20, 2200)
 
   return (
     <S.HeroSection id={Sec.HERO}>
@@ -17,6 +21,9 @@ const Hero: React.FC = () => {
           <S.HeroSubtitle>
             {displayText}<S.Cursor />
           </S.HeroSubtitle>
+          <S.HeroJoke>
+            {jokeText}<S.Cursor />
+          </S.HeroJoke>
         </S.FadeUp>
         <S.FadeUp delay={500}>
           <S.HeroBio>


### PR DESCRIPTION
## Summary
- Added a second typewriter line below the main subtitle that cycles through joke titles (`JOKES` array)
- `TITLES` cycles professional roles (Capital One, Georgia Tech, UIUC)
- `JOKES` cycles humorous alt-titles (Claude Code, 3AM, Sunday League, Bedroom Studio, Starbucks Reserve)
- New `HeroJoke` styled component: italic, accent color, 50% opacity — clearly secondary/playful

## Test plan
- [ ] Main subtitle cycles through all three professional titles
- [ ] Joke line cycles independently below it
- [ ] Both cursors blink correctly
- [ ] Styling looks distinct enough between the two lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)