### PR TITLE
Fix mobile navbar: pin toggle, scrollable nav links

### DIFF
--- a/src/App.style.ts
+++ b/src/App.style.ts
@@ -3,5 +3,6 @@ import styled from "styled-components"
 export const AppContainer = styled.div`
   background-color: ${props => props.theme.background};
   min-height: 100vh;
+  overflow-x: hidden;
   transition: background 0.5s;
 `

--- a/src/components/NavigationBar/NavigationBar.style.js
+++ b/src/components/NavigationBar/NavigationBar.style.js
@@ -20,12 +20,27 @@ export const NavigationContainer = styled.nav`
   gap: 0.25rem;
 
   ${media.tablet`
-    padding: 0 1.25rem;
+    padding: 0 1rem 0 0.75rem;
     gap: 0;
+    justify-content: space-between;
   `}
+`
 
-  ${media.phone`
-    justify-content: center;
+export const NavLinks = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  ${media.tablet`
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    flex: 1;
+    gap: 0;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   `}
 `
 
@@ -40,6 +55,7 @@ const NavItemCSS = css`
   opacity: 0.55;
   transition: opacity 0.2s ease-in-out;
   white-space: nowrap;
+  flex-shrink: 0;
   border-radius: 6px;
 
   &:hover {

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import {
   NavigationContainer,
+  NavLinks,
   NavAnchor,
   ThemeToggle,
 } from "./NavigationBar.style"
@@ -46,15 +47,17 @@ const NavigationBar: React.FC<INavigationBarProps> = ({ onThemeToggle, isDark })
 
   return (
     <NavigationContainer>
-      {NAV_ITEMS.map(item => (
-        <NavAnchor
-          key={item.label}
-          href={item.href}
-          className={activeSection === item.href.slice(1) ? "active" : ""}
-        >
-          {item.label}
-        </NavAnchor>
-      ))}
+      <NavLinks>
+        {NAV_ITEMS.map(item => (
+          <NavAnchor
+            key={item.label}
+            href={item.href}
+            className={activeSection === item.href.slice(1) ? "active" : ""}
+          >
+            {item.label}
+          </NavAnchor>
+        ))}
+      </NavLinks>
       <ThemeToggle onClick={onThemeToggle} aria-label="Toggle theme" {...{ isDark }} />
     </NavigationContainer>
   )

--- a/src/sections/Hero/Hero.style.ts
+++ b/src/sections/Hero/Hero.style.ts
@@ -27,18 +27,20 @@ export const HeroSection = styled.section`
   min-height: 100vh;
   display: flex;
   align-items: center;
-  padding: 0 40px;
+  padding: 60px 40px 0;
   max-width: 1100px;
   margin: 0 auto;
   position: relative;
   overflow: hidden;
 
   @media (max-width: ${sizes.tablet}px) {
-    padding: 0 24px;
+    padding: 60px 24px 0;
   }
 
   @media (max-width: ${sizes.phone}px) {
-    padding: 0 16px;
+    padding: 60px 16px 0;
+    align-items: flex-start;
+    padding-top: 80px;
   }
 `
 


### PR DESCRIPTION
## Summary
- Extracted `NavLinks` wrapper around nav anchors that scrolls independently on mobile
- Toggle is now always pinned to the right outside the scroll container — always visible on load
- `NavigationContainer` uses `space-between` on tablet/mobile to separate links from toggle
- Hero section `padding-top` accounts for the fixed 60px navbar height on all breakpoints

## Test plan
- [ ] Toggle is visible and accessible on mobile without scrolling
- [ ] Nav links (About → Contact) are swipeable on mobile
- [ ] Active section highlight still works correctly
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)