### PR TITLE
Fix typewriter layout shift on mobile

### DIFF
--- a/src/sections/Hero/Hero.style.ts
+++ b/src/sections/Hero/Hero.style.ts
@@ -113,6 +113,14 @@ export const HeroName = styled.h1`
   color: transparent;
 `
 
+export const SubtitleBlock = styled.div`
+  min-height: 3.8rem;
+
+  @media (max-width: ${sizes.tablet}px) {
+    min-height: 4.8rem;
+  }
+`
+
 export const HeroSubtitle = styled.p`
   font-size: clamp(1rem, 2vw, 1.25rem);
   color: ${props => props.theme.color};

--- a/src/sections/Hero/Hero.tsx
+++ b/src/sections/Hero/Hero.tsx
@@ -18,12 +18,14 @@ const Hero: React.FC = () => {
         <S.FadeUp delay={50}><S.HeroEyebrow>Full-Stack Software Engineer</S.HeroEyebrow></S.FadeUp>
         <S.FadeUp delay={200}><S.HeroName>Yoon Chang</S.HeroName></S.FadeUp>
         <S.FadeUp delay={350}>
-          <S.HeroSubtitle>
-            {displayText}<S.Cursor />
-          </S.HeroSubtitle>
-          <S.HeroJoke>
-            {jokeText}<S.Cursor />
-          </S.HeroJoke>
+          <S.SubtitleBlock>
+            <S.HeroSubtitle>
+              {displayText}<S.Cursor />
+            </S.HeroSubtitle>
+            <S.HeroJoke>
+              {jokeText}<S.Cursor />
+            </S.HeroJoke>
+          </S.SubtitleBlock>
         </S.FadeUp>
         <S.FadeUp delay={500}>
           <S.HeroBio>


### PR DESCRIPTION
## Summary
- Wraps both typewriter lines (`HeroSubtitle` + `HeroJoke`) in a new `SubtitleBlock` container
- `SubtitleBlock` reserves a fixed `min-height` (3.8rem desktop, 4.8rem tablet/mobile) so the block never shrinks during the type-out phase
- Prevents hero content and sections below from shifting while scrolling on mobile

## Test plan
- [ ] Scroll down on mobile while typewriter is animating — other sections should stay put
- [ ] Verify spacing between the two typewriter lines looks unchanged
- [ ] Check desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)